### PR TITLE
Make tests pass after migration to Mocha

### DIFF
--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -56,19 +56,15 @@ export async function withFixtures(
   const origDir = process.cwd();
   process.chdir(dir.name);
 
-  let result;
-
   try {
-    result = await fn(dir.name);
-  } catch (e) {
+    const result = await fn(dir.name);
+
+    if (!keep) {
+      dir.removeCallback();
+    }
+
+    return result;
+  } finally {
     process.chdir(origDir);
-    throw e;
   }
-
-  process.chdir(origDir);
-  if (!keep) {
-    dir.removeCallback();
-  }
-
-  return result;
 }

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -56,7 +56,14 @@ export async function withFixtures(
   const origDir = process.cwd();
   process.chdir(dir.name);
 
-  const result = await fn(dir.name);
+  let result;
+
+  try {
+    result = await fn(dir.name);
+  } catch (e) {
+    process.chdir(origDir);
+    throw e;
+  }
 
   process.chdir(origDir);
   if (!keep) {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,3 @@
 --require source-map-support/register
---timeout 10000
+--timeout 30000
 --throw-deprecation

--- a/test/test-clean.ts
+++ b/test/test-clean.ts
@@ -34,7 +34,7 @@ describe('clean', () => {
   };
 
   it('should gracefully error if tsconfig is missing', async () => {
-    await assert.rejects(
+    await assert.rejects(() =>
       withFixtures({}, async () => {
         await clean(OPTIONS);
       })
@@ -59,7 +59,7 @@ describe('clean', () => {
   });
 
   it('should ensure that outDir is local to targetRoot', async () => {
-    await assert.rejects(
+    await assert.rejects(() =>
       withFixtures(
         {
           'tsconfig.json': JSON.stringify({

--- a/test/test-format.ts
+++ b/test/test-format.ts
@@ -28,11 +28,10 @@ describe('format', () => {
   const BAD_CODE = 'export const foo = [ "2" ];';
   const GOOD_CODE = "export const foo = ['2'];\n";
   const CODE_WITH_TABS = `module.exports = {
-  \treallyLongIdentified: 4,
-  \tanotherSuperLongIdentifier,
-  \tthisCannotFitOnTheSameLine
-  };\n`;
-
+\treallyLongIdentified: 4,
+\tanotherSuperLongIdentifier,
+\tthisCannotFitOnTheSameLine
+};\n`;
   const PRETTIER_FORMAT_MESSAGE =
     'prettier reported errors... run `gts fix` to address.';
 

--- a/test/test-kitchen.ts
+++ b/test/test-kitchen.ts
@@ -119,10 +119,13 @@ describe('🚰 kitchen sink', () => {
       'utf8'
     );
     const tsconfig = JSON.parse(tsconfigJson);
-    //t.deepEqual(tsconfig.extends, './node_modules/gts/tsconfig-google.json');
+    assert.deepStrictEqual(
+      tsconfig.extends,
+      './node_modules/gts/tsconfig-google.json'
+    );
 
     // server.ts has a lint error. Should error.
-    //await t.throwsAsync(simpleExecp(`${GTS} check src/server.ts`, opts));
+    await assert.rejects(() => simpleExecp(`${GTS} check src/server.ts`, opts));
 
     if (!keep) {
       tmpDir.removeCallback();
@@ -182,9 +185,7 @@ describe('🚰 kitchen sink', () => {
    */
   it('should clean', async () => {
     await simpleExecp('npm run clean', execOpts);
-    // t.throws(() => {
-    //   fs.accessSync(`${stagingPath}/kitchen/build`);
-    // });
+    assert.throws(() => fs.accessSync(`${stagingPath}/kitchen/build`));
   });
 
   /**

--- a/test/test-kitchen.ts
+++ b/test/test-kitchen.ts
@@ -152,7 +152,7 @@ describe('🚰 kitchen sink', () => {
     assert.notStrictEqual(stdout.indexOf('prettier reported errors'), -1);
   });
 
-  it('should fix', async t => {
+  it('should fix', async () => {
     const preFix = fs
       .readFileSync(`${stagingPath}/kitchen/src/server.ts`, 'utf8')
       .split('\n');
@@ -167,7 +167,7 @@ describe('🚰 kitchen sink', () => {
     await simpleExecp('npm run check', execOpts);
   });
 
-  it('should build', async t => {
+  it('should build', async () => {
     await simpleExecp('npm run compile', execOpts);
     fs.accessSync(`${stagingPath}/kitchen/build/src/server.js`);
     fs.accessSync(`${stagingPath}/kitchen/build/src/server.js.map`);

--- a/test/test-kitchen.ts
+++ b/test/test-kitchen.ts
@@ -142,7 +142,9 @@ describe('🚰 kitchen sink', () => {
         .endsWith('\n')
     );
     assert.ok(
-      fs.readFileSync(`${stagingPath}/kitchen/tslint.json`, 'utf8').endsWith('\n')
+      fs
+        .readFileSync(`${stagingPath}/kitchen/tslint.json`, 'utf8')
+        .endsWith('\n')
     );
   });
 

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -66,7 +66,7 @@ describe('util', () => {
     myMap.set('/some/fake/directory/FAKE_CONFIG3', FAKE_CONFIG3);
 
     await assert.rejects(
-      getTSConfig(FAKE_DIRECTORY, createFakeReadFilep(myMap)),
+      () => getTSConfig(FAKE_DIRECTORY, createFakeReadFilep(myMap)),
       Error,
       'Circular Reference Detected'
     );
@@ -146,7 +146,7 @@ describe('util', () => {
     const myMap = new Map();
 
     await assert.rejects(
-      getTSConfig(FAKE_DIRECTORY, createFakeReadFilep(myMap)),
+      () => getTSConfig(FAKE_DIRECTORY, createFakeReadFilep(myMap)),
       Error,
       `${FAKE_DIRECTORY}/tsconfig.json Not Found`
     );


### PR DESCRIPTION
The first PR in a series. Here's a PR which makes tests pass.

The next should be:

- [ ] resolving conflicts with master (migrate more tests)
- [x] get back what's commented now (**done within this PR**)