### PR TITLE
fix: Remove manual package.json interface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -499,6 +499,12 @@
       "integrity": "sha512-nMRqS+mL1TOnIJrL6LKJcNZPB8V3eTfRo9FQA2b5gDvrHurC8XbSA86KNe0dShlEL7ReWJv/OU9NL7Z0dnqWTg==",
       "dev": true
     },
+    "@types/package-json": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/package-json/-/package-json-5.0.0.tgz",
+      "integrity": "sha512-WqgImkz7tkh6c9PUCchGrAkFpyWsrLMuxwoe267IBVs5hxnyG6piWQ69KrV+cESDPz5np2d06ocqBkQYO41jKQ==",
+      "dev": true
+    },
     "@types/pify": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/pify/-/pify-3.0.2.tgz",
@@ -2110,8 +2116,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2132,14 +2137,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2154,20 +2157,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2284,8 +2284,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2297,7 +2296,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2312,7 +2310,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2320,14 +2317,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2346,7 +2341,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2427,8 +2421,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2440,7 +2433,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2526,8 +2518,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2563,7 +2554,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2583,7 +2573,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2627,14 +2616,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@types/meow": "^5.0.0",
     "@types/ncp": "^2.0.1",
     "@types/node": "^10.0.3",
+    "@types/package-json": "^5.0.0",
     "@types/pify": "^3.0.2",
     "@types/prettier": "^1.15.2",
     "@types/rimraf": "^2.0.2",

--- a/src/init.ts
+++ b/src/init.ts
@@ -13,18 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import chalk from 'chalk';
 import * as cp from 'child_process';
 import * as inquirer from 'inquirer';
 import * as path from 'path';
 
-import { Options } from './cli';
 import {
+  getPkgManagerName,
   readFilep as read,
   readJsonp as readJson,
   writeFileAtomicp as write,
-  getPkgManagerName,
 } from './util';
+
+import { Options } from './cli';
+import { PackageJson } from 'package-json';
+import chalk from 'chalk';
 
 const pkg = require('../../package.json');
 
@@ -42,21 +44,6 @@ const DEFAULT_PACKAGE_JSON: PackageJson = {
 
 export interface Bag<T> {
   [script: string]: T;
-}
-
-// TODO: is this type available from definitelytyped.org? Find it, and drop the
-// local definition.
-export interface PackageJson {
-  version?: string;
-  devDependencies?: Bag<string>;
-  scripts?: Bag<string>;
-  name?: string;
-  description?: string;
-  main?: string;
-  types?: string;
-  files?: string[];
-  license?: string;
-  keywords?: string[];
 }
 
 async function query(

--- a/test/test-init.ts
+++ b/test/test-init.ts
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-import test from 'ava';
+import * as init from '../src/init';
 import * as path from 'path';
 
-import { Options } from '../src/cli';
-import * as init from '../src/init';
 import { nop, readJsonp as readJson } from '../src/util';
 
+import { Options } from '../src/cli';
+import { PackageJson } from 'package-json';
+import test from 'ava';
 import { withFixtures } from './fixtures';
 
 const OPTIONS: Options = {
@@ -35,7 +36,7 @@ const OPTIONS_YES = Object.assign({}, OPTIONS, { yes: true });
 const OPTIONS_NO = Object.assign({}, OPTIONS, { no: true });
 const OPTIONS_YARN = Object.assign({}, OPTIONS_YES, { yarn: true });
 
-function hasExpectedScripts(packageJson: init.PackageJson): boolean {
+function hasExpectedScripts(packageJson: PackageJson): boolean {
   return (
     !!packageJson.scripts &&
     [
@@ -50,7 +51,7 @@ function hasExpectedScripts(packageJson: init.PackageJson): boolean {
   );
 }
 
-function hasExpectedDependencies(packageJson: init.PackageJson): boolean {
+function hasExpectedDependencies(packageJson: PackageJson): boolean {
   return (
     !!packageJson.devDependencies &&
     ['gts', 'typescript'].every(d => !!packageJson.devDependencies![d])
@@ -58,7 +59,7 @@ function hasExpectedDependencies(packageJson: init.PackageJson): boolean {
 }
 
 test('addScripts should add a scripts section if none exists', async t => {
-  const pkg: init.PackageJson = {};
+  const pkg: PackageJson = {};
   const result = await init.addScripts(pkg, OPTIONS);
   t.is(result, true); // made edits.
   t.truthy(pkg.scripts);
@@ -75,7 +76,7 @@ test('addScripts should not edit existing scripts on no', async t => {
     pretest: `fake run compile`,
     posttest: `fake run check`,
   };
-  const pkg: init.PackageJson = { scripts: Object.assign({}, SCRIPTS) };
+  const pkg: PackageJson = { scripts: Object.assign({}, SCRIPTS) };
 
   const result = await init.addScripts(pkg, OPTIONS_NO);
   t.is(result, false); // no edits.
@@ -92,14 +93,14 @@ test('addScripts should edit existing scripts on yes', async t => {
     pretest: `fake run compile`,
     posttest: `fake run check`,
   };
-  const pkg: init.PackageJson = { scripts: Object.assign({}, SCRIPTS) };
+  const pkg: PackageJson = { scripts: Object.assign({}, SCRIPTS) };
   const result = await init.addScripts(pkg, OPTIONS_YES);
   t.is(result, true); // made edits.
   t.notDeepEqual(pkg.scripts, SCRIPTS);
 });
 
 test('addDependencies should add a deps section if none exists', async t => {
-  const pkg: init.PackageJson = {};
+  const pkg: PackageJson = {};
   const result = await init.addDependencies(pkg, OPTIONS);
   t.is(result, true); // made edits.
   t.truthy(pkg.devDependencies);
@@ -107,7 +108,7 @@ test('addDependencies should add a deps section if none exists', async t => {
 
 test('addDependencies should not edit existing deps on no', async t => {
   const DEPS = { gts: 'something', typescript: 'or the other' };
-  const pkg: init.PackageJson = { devDependencies: Object.assign({}, DEPS) };
+  const pkg: PackageJson = { devDependencies: Object.assign({}, DEPS) };
   const OPTIONS_NO = Object.assign({}, OPTIONS, { no: true });
   const result = await init.addDependencies(pkg, OPTIONS_NO);
   t.is(result, false); // no edits.
@@ -116,7 +117,7 @@ test('addDependencies should not edit existing deps on no', async t => {
 
 test('addDependencies should edit existing deps on yes', async t => {
   const DEPS = { gts: 'something', typescript: 'or the other' };
-  const pkg: init.PackageJson = { devDependencies: Object.assign({}, DEPS) };
+  const pkg: PackageJson = { devDependencies: Object.assign({}, DEPS) };
 
   const result = await init.addDependencies(pkg, OPTIONS_YES);
   t.is(result, true); // made edits.


### PR DESCRIPTION
- Removes manual `package.json` types.
  - Uses `@types/package-json` instead.

Note: Import order sorted automatically via VSCode.