### PR TITLE
fix!: lint enforce trailing commas

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -53,6 +53,18 @@
     "radix": true,
     "semicolon": [true, "always", "ignore-bound-class-methods"],
     "switch-default": true,
+    "trailing-comma": [
+      true,
+      {
+        "multiline": {
+          "objects": "always",
+          "arrays": "always",
+          "functions": "never",
+          "typeLiterals": "ignore"
+        },
+        "esSpecCompliant": true
+      }
+    ],
     "triple-equals": [true, "allow-null-check"],
     "use-isnan": true,
     "variable-name": [


### PR DESCRIPTION
While not part of the internal style guide (yet), enforcing trailing
commas make sense as they make diffs simpler. They would would give us
better congruence with the JS style guide.

Fixes: https://github.com/google/gts/issues/292