### PR TITLE
build: use npm ci in the ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ unit_tests: &unit_tests
     - checkout
     - run:
         name: Install modules and dependencies.
-        command: npm install
+        command: npm ci
     - run:
         name: Run unit tests.
         command: npm test
@@ -67,7 +67,7 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
       - run:
           name: Install modules and dependencies.
-          command: npm install
+          command: npm ci
       - run:
           name: Publish the module to npm.
           command: npm publish


### PR DESCRIPTION
CI should use npm-ci to install https://docs.npmjs.com/cli/ci.html. It
is faster cleaner and stricter and doesn't update package-lock as part
of the install.