### PR TITLE
chore: remove redundant dependency (mkdir)

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "execa": "^1.0.0",
     "inline-fixtures": "^1.0.0",
     "js-green-licenses": "^0.5.0",
-    "make-dir": "^2.1.0",
     "mocha": "^6.0.0",
     "ncp": "^2.0.0",
     "nyc": "^13.3.0",


### PR DESCRIPTION
It's redundant after #299 (make-dir will be installed as a dependency of `inline-fixture`)