### PR TITLE
append .cmd to npm/yarn command when in Windows

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -281,8 +281,10 @@ export async function init(options: Options): Promise<boolean> {
   if (!options.dryRun) {
     // --ignore-scripts so that compilation doesn't happen because there's no
     // source files yet.
+    let command = getPkgManagerName(options.yarn);
+    if (process.platform === 'win32') command += '.cmd';
     cp.spawnSync(
-      getPkgManagerName(options.yarn),
+      command,
       ['install', '--ignore-scripts'],
       { stdio: 'inherit' }
     );

--- a/src/init.ts
+++ b/src/init.ts
@@ -283,11 +283,9 @@ export async function init(options: Options): Promise<boolean> {
     // source files yet.
     let command = getPkgManagerName(options.yarn);
     if (process.platform === 'win32') command += '.cmd';
-    cp.spawnSync(
-      command,
-      ['install', '--ignore-scripts'],
-      { stdio: 'inherit' }
-    );
+    cp.spawnSync(command, ['install', '--ignore-scripts'], {
+      stdio: 'inherit',
+    });
   }
 
   return true;


### PR DESCRIPTION
fix #278 

Got a bunch of error when running mocha test on Windows...