### PR TITLE
fix: process less files in parallel preventing OOM errors

### DIFF
--- a/src/lint.ts
+++ b/src/lint.ts
@@ -20,8 +20,7 @@ import * as ts from 'typescript';
 
 import { Options } from './cli';
 
-// how many files should we lint in conjunction before creating a new linter?
-const MAX_FILES_LINTED = 25;
+const MAX_PARALLEL_FILES = 25;
 
 /**
  * Run tslint with the default configuration. Returns true on success.
@@ -80,9 +79,9 @@ export function lint(
 
     let linter: Linter | undefined = undefined;
     for (let i = 0; i < files.length; i++) {
-      // only lint MAX_FILES_LINTED at one time, to prevent OOM errors
-      // on code-bases with large numbers of files:
-      if (i % MAX_FILES_LINTED === 0) {
+      // only lint MAX_PARALLEL_FILES at one time, this prevents OOM errors
+      // on codebases with large numbers of files:
+      if (i % MAX_PARALLEL_FILES === 0) {
         if (linter) {
           const result = linter!.getResult();
           if (result.errorCount || result.warningCount) {
@@ -100,7 +99,7 @@ export function lint(
       }
     }
 
-    // handle source files most recently added to linter:
+    // handle the final set of source files added to the linter:
     if (linter) {
       const result = linter.getResult();
       if (result.errorCount || result.warningCount) {

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -75,7 +75,7 @@ export function lint(
 
     const configuration = Configuration.loadConfigurationFromPath(configPath);
 
-    for (let file of files) {
+    for (const file of files) {
       const sourceFile = program.getSourceFile(file);
       if (sourceFile) {
         const fileContents = sourceFile.getFullText();

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -75,8 +75,7 @@ export function lint(
 
     const configuration = Configuration.loadConfigurationFromPath(configPath);
 
-    for (let i = 0; i < files.length; i++) {
-      const file = files[i];
+    for (let file of files) {
       const sourceFile = program.getSourceFile(file);
       if (sourceFile) {
         const fileContents = sourceFile.getFullText();


### PR DESCRIPTION
## The Problem

tslint seems to have a memory leak such that, in codebases with a lot of files like `google-api-nodejs-client`, we're bumping into OOM issues, here's an example: 

https://github.com/googleapis/google-api-nodejs-client/pull/1778

The problem crops up when `getResult` is called on a large set of files.

## Solution

It doesn't seem like, for the purposes of linting, there should be any state shared between the files added to the linter, this PR proposes linting a maximum of 25 files in conjunction, and then creating a new `Linter` instance.

I've confirmed that this fixes our issues with `google-api-nodejs-client`.
