### PR TITLE
build: use release-please

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,0 +1,2 @@
+releaseType: node
+handleGHRelease: true


### PR DESCRIPTION
I'd like to cut a new release for TypeScript 3.7 support, but I just can't be bothered to follow the old process anymore.  @bcoe has ruined me. 