### PR TITLE
fix!: drop support for node 8

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,7 +7,7 @@ windows_task:
     os_version: 2019
     docker_arguments:
       matrix:
-        - node_version: 12.14.1
+        - node_version: 12.1.0
   install_script: npm ci
   test_script: npm test
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,8 +7,7 @@ windows_task:
     os_version: 2019
     docker_arguments:
       matrix:
-        - node_version: 12.1.0
-        - node_version: 11.14.0
+        - node_version: 12.14.1
   install_script: npm ci
   test_script: npm test
 
@@ -30,7 +29,6 @@ test_task:
       image: node:13
       image: node:12
       image: node:10
-      image: node:8
   install_script: npm ci
   test_script: npm test
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -497,15 +497,6 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
-    "assert-rejects": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-rejects/-/assert-rejects-1.0.0.tgz",
-      "integrity": "sha512-xSmDqs5YxfrHUQBhVfrP/5+UoEvMBTY2+oRDoLfY9zsTA1hnW0KiKYcXKyeVWSgb0UpsQ4gyeBuKlXKzKUobZA==",
-      "dev": true,
-      "requires": {
-        "is-regexp": "^1.0.0"
-      }
-    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -2003,12 +1994,6 @@
       "requires": {
         "has": "^1.0.3"
       }
-    },
-    "is-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
-      "dev": true
     },
     "is-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "fix": "eslint --fix '**/*.ts'"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "keywords": [],
   "author": "Google Inc.",
@@ -70,7 +70,6 @@
     "@types/tmp": "^0.1.0",
     "@types/update-notifier": "^2.2.0",
     "@types/write-file-atomic": "^3.0.0",
-    "assert-rejects": "^1.0.0",
     "c8": "^7.0.0",
     "chai": "^4.2.0",
     "codecov": "^3.0.1",

--- a/tsconfig-google.json
+++ b/tsconfig-google.json
@@ -4,7 +4,7 @@
     "allowUnusedLabels": false,
     "declaration": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["es2016"],
+    "lib": ["es2018"],
     "module": "commonjs",
     "noEmitOnError": true,
     "noFallthroughCasesInSwitch": true,
@@ -12,7 +12,7 @@
     "pretty": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es2017"
+    "target": "es2018"
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
BREAKING CHANGE: This commit drops support for node.js 8.x.  Additionally, the base tsconfig has been upgraded to target the es2018 feature set, which is fully supported by node.js 10.x.