### PR TITLE
docs: example template compile fix

### DIFF
--- a/template/index.ts
+++ b/template/index.ts
@@ -19,5 +19,7 @@ export function doSomeStuff(
   console.log(withThis);
   console.log(andThat);
   console.dir(andThose);
+  
+  return;
 }
 // TODO: more examples

--- a/template/index.ts
+++ b/template/index.ts
@@ -19,7 +19,6 @@ export function doSomeStuff(
   console.log(withThis);
   console.log(andThat);
   console.dir(andThose);
-  
   return;
 }
 // TODO: more examples


### PR DESCRIPTION
Template can't be compiled because of `TS7030`.

```
 error TS7030: Not all code paths return a value.
```

Fixed by adding dummy return.