### PR TITLE
refactor: compile using tsc with no arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build": "npm run compile",
     "clean": "rimraf ./build/",
     "codecov": "c8 report --reporter=json && codecov -f coverage/*.json",
-    "compile": "tsc -p .",
+    "compile": "tsc",
     "postcompile": "ncp template build/template",
     "lint": "eslint '**/*.ts'",
     "prepare": "npm run compile",

--- a/src/init.ts
+++ b/src/init.ts
@@ -84,7 +84,7 @@ export async function addScripts(
   const scripts: Bag<string> = {
     check: `gts check`,
     clean: 'gts clean',
-    compile: `tsc -p .`,
+    compile: `tsc`,
     fix: `gts fix`,
     prepare: `${pkgManager} run compile`,
     pretest: `${pkgManager} run compile`,

--- a/test/test-init.ts
+++ b/test/test-init.ts
@@ -86,7 +86,7 @@ describe('init', () => {
     const SCRIPTS = {
       check: `fake check`,
       clean: 'fake clean',
-      compile: `fake tsc -p .`,
+      compile: `fake tsc`,
       fix: `fake fix`,
       prepare: `fake run compile`,
       pretest: `fake run compile`,
@@ -105,7 +105,7 @@ describe('init', () => {
     const SCRIPTS = {
       check: `fake check`,
       clean: 'fake clean',
-      compile: `fake tsc -p .`,
+      compile: `fake tsc`,
       fix: `fake fix`,
       prepare: `fake run compile`,
       pretest: `fake run compile`,


### PR DESCRIPTION
Since TypeScript [v1.5.0-alpha](https://github.com/microsoft/TypeScript/blob/b18dd53242df31163390c411ac7ab5e9c282fea2/src/compiler/tsc.ts#L185) `tsc` will search for `tsconfig.json` in `cwd` by default.

First implemented in https://github.com/microsoft/TypeScript/pull/1692.

So, there's no need in specifying project path anymore and we can safely replace `tsc -p .` with just `tsc`.