### PR TITLE
feat: allow eslintrc to run over tsx files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,7 +20,7 @@
   },
   "overrides": [
     {
-      "files": "**/*.ts",
+      "files": ["**/*.ts", "**/*.tsx"],
       "parser": "@typescript-eslint/parser",
       "extends": [
         "plugin:@typescript-eslint/recommended"


### PR DESCRIPTION
The current eslintrc ignores tsx files.