### PR TITLE
fix: enable trailing comma

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,6 @@
 {
   "bracketSpacing": false,
   "singleQuote": true,
+  "trailingComma": "es5",
   "arrowParens": "avoid"
 }


### PR DESCRIPTION
Put it back. Will be released as `2.0.0-alpha.8` and tagged `next`.