### PR TITLE
fix: disable no-var-requires

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,6 +28,7 @@
       "rules": {
         "@typescript-eslint/no-non-null-assertion": "off",
         "@typescript-eslint/no-use-before-define": "off",
+        "@typescript-eslint/no-var-requires": "off",
         "@typescript-eslint/no-warning-comments": "off",
         "@typescript-eslint/no-empty-function": "off",
         "@typescript-eslint/explicit-function-return-type": "off",


### PR DESCRIPTION
This one is arguable, I'm open for discussion here (but I would just disable it for now, we can work on refactoring _a lot_ of code to reduce `require` s by the time gts 3.0.0 comes :) 