### PR TITLE
feat!: prefer single quotes if possible, raising warning

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,7 +16,8 @@
     "prefer-const": "error",
     "eol-last": "error",
     "prefer-arrow-callback": "error",
-    "no-trailing-spaces": "error"
+    "no-trailing-spaces": "error",
+    "quotes": ["warn", "single", { "avoidEscape": true }]
   },
   "overrides": [
     {

--- a/src/clean.ts
+++ b/src/clean.ts
@@ -33,7 +33,7 @@ export async function clean(options: Options): Promise<boolean> {
     if (outDir === '.') {
       options.logger.error(
         `${chalk.red('ERROR:')} ${chalk.gray('compilerOptions.outDir')} ` +
-          `cannot use the value '.'.  That would delete all of our sources.`
+          'cannot use the value ".".  That would delete all of our sources.'
       );
       return false;
     }
@@ -45,7 +45,7 @@ export async function clean(options: Options): Promise<boolean> {
     options.logger.error(
       `${chalk.red('ERROR:')} The ${chalk.gray('clean')} command` +
         ` requires ${chalk.gray('compilerOptions.outDir')} to be defined in ` +
-        `tsconfig.json.`
+        'tsconfig.json.'
     );
     return false;
   }

--- a/src/init.ts
+++ b/src/init.ts
@@ -82,10 +82,10 @@ export async function addScripts(
   let edits = false;
   const pkgManager = getPkgManagerCommand(options.yarn);
   const scripts: Bag<string> = {
-    check: `gts check`,
+    check: 'gts check',
     clean: 'gts clean',
-    compile: `tsc`,
-    fix: `gts fix`,
+    compile: 'tsc',
+    fix: 'gts fix',
     prepare: `${pkgManager} run compile`,
     pretest: `${pkgManager} run compile`,
     posttest: `${pkgManager} run check`,
@@ -285,7 +285,7 @@ export async function init(options: Options): Promise<boolean> {
     }
     const generate = await query(
       `${chalk.bold('package.json')} does not exist.`,
-      `Generate`,
+      'Generate',
       true,
       options
     );

--- a/test/test-init.ts
+++ b/test/test-init.ts
@@ -84,13 +84,13 @@ describe('init', () => {
 
   it('addScripts should not edit existing scripts on no', async () => {
     const SCRIPTS = {
-      check: `fake check`,
+      check: 'fake check',
       clean: 'fake clean',
-      compile: `fake tsc`,
-      fix: `fake fix`,
-      prepare: `fake run compile`,
-      pretest: `fake run compile`,
-      posttest: `fake run check`,
+      compile: 'fake tsc',
+      fix: 'fake fix',
+      prepare: 'fake run compile',
+      pretest: 'fake run compile',
+      posttest: 'fake run check',
     };
     const pkg: PackageJson = {
       ...MINIMAL_PACKAGE_JSON,
@@ -103,13 +103,13 @@ describe('init', () => {
 
   it('addScripts should edit existing scripts on yes', async () => {
     const SCRIPTS = {
-      check: `fake check`,
+      check: 'fake check',
       clean: 'fake clean',
-      compile: `fake tsc`,
-      fix: `fake fix`,
-      prepare: `fake run compile`,
-      pretest: `fake run compile`,
-      posttest: `fake run check`,
+      compile: 'fake tsc',
+      fix: 'fake fix',
+      prepare: 'fake run compile',
+      pretest: 'fake run compile',
+      posttest: 'fake run check',
     };
     const pkg: PackageJson = {
       ...MINIMAL_PACKAGE_JSON,


### PR DESCRIPTION
Warn if single quotes are not used in a situation in which this is possible. see: https://eslint.org/docs/rules/quotes

This rule lets us catch the [behavior discussed here](https://github.com/googleapis/google-cloud-node/issues/2915), in which a template string is used with no replacements.

I've opted for a warning rather than an error, as in testing it seemed like this rule could be a bit disruptive for folks who write strings like this:

```
"hello 'world'"
```

as it requires the replacement:

```
'hello "world"'
```

fixes: https://github.com/googleapis/google-cloud-node/issues/2915