### PR TITLE
feat!(eslint): reinstate variable-name as naming-convention #486

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,7 +34,7 @@
         "@typescript-eslint/explicit-function-return-type": "off",
         "@typescript-eslint/camelcase": "off",
         "@typescript-eslint/naming-convention": [
-          "warn",
+          "error",
           {
             "selector": "variable",
             "format": ["camelCase", "UPPER_CASE"],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,6 +33,19 @@
         "@typescript-eslint/no-empty-function": "off",
         "@typescript-eslint/explicit-function-return-type": "off",
         "@typescript-eslint/camelcase": "off",
+        "@typescript-eslint/naming-convention": [
+          "warn",
+          {
+            "selector": "variable",
+            "format": ["camelCase", "UPPER_CASE"],
+            "leadingUnderscore": "allow",
+            "trailingUnderscore": "allow",
+            "custom": {
+              "regex": "any|[Nn]umber|[Ss]tring|[Bb]oolean|[Uu]ndefined",
+              "match": false
+            }
+          }
+        ],
         "node/no-missing-import": "off",
         "node/no-empty-function": "off",
         "node/no-unsupported-features/es-syntax": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -39,11 +39,7 @@
             "selector": "variable",
             "format": ["camelCase", "UPPER_CASE"],
             "leadingUnderscore": "allow",
-            "trailingUnderscore": "allow",
-            "custom": {
-              "regex": "any|[Nn]umber|[Ss]tring|[Bb]oolean|[Uu]ndefined",
-              "match": false
-            }
+            "trailingUnderscore": "allow"
           }
         ],
         "node/no-missing-import": "off",


### PR DESCRIPTION
BREAKING CHANGE

- configured as `error` level
- not 1:1 with legacy `variable-name`, does not blacklist primitive type names in identifier name
- scoped to _variables_ only, e.g. no effect on interfaces for method names etc. see https://github.com/google/gts/pull/487/files#r410749633

Fixes #486 

~Configured as `warn` level so as not to be a breaking change, unless using `--max-warnings`.~