### PR TITLE
fix: throw an error if running with an unsupported version of nodejs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 > Google TypeScript Style
 
 [![NPM Version][npm-image]][npm-url]
-[![CircleCI][circle-image]][circle-url]
+[![GitHub Actions][github-image]][github-url]
 [![Dependency Status][david-image]][david-url]
 [![Known Vulnerabilities][snyk-image]][snyk-url]
 [![codecov][codecov-image]][codecov-url]
@@ -74,6 +74,9 @@ Show your love for `gts` and include a badge!
 [![Code Style: Google](https://img.shields.io/badge/code%20style-google-blueviolet.svg)](https://github.com/google/gts)
 ```
 
+## Supported Node.js Versions
+Our client libraries follow the [Node.js release schedule](https://nodejs.org/en/about/releases/). Libraries are compatible with all current _active_ and _maintenance_ versions of Node.js.
+
 ## License
 [Apache-2.0](LICENSE)
 
@@ -82,8 +85,8 @@ Made with ❤️ by the Google Node.js team.
 
 > ***NOTE: This is not an official Google product.***
 
-[circle-image]: https://circleci.com/gh/google/gts.svg?style=shield
-[circle-url]: https://circleci.com/gh/google/gts
+[github-image]: https://github.com/google/gts/workflows/ci/badge.svg
+[github-url]: https://github.com/google/gts/actions
 [prettier-url]: https://prettier.io/
 [codecov-image]: https://codecov.io/gh/google/gts/branch/master/graph/badge.svg
 [codecov-url]: https://codecov.io/gh/google/gts

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -84,6 +84,15 @@ const cli = meow({
   },
 });
 
+/**
+ * Get the current version of node.js being run.
+ * Exported purely for stubbing purposes.
+ * @private
+ */
+export function getNodeVersion() {
+  return process.version;
+}
+
 function usage(msg?: string): void {
   if (msg) {
     logger.error(msg);
@@ -91,7 +100,18 @@ function usage(msg?: string): void {
   cli.showHelp(1);
 }
 
-async function run(verb: string, files: string[]): Promise<boolean> {
+export async function run(verb: string, files: string[]): Promise<boolean> {
+  // throw if running on an old version of nodejs
+  const nodeMajorVersion = Number(getNodeVersion().slice(1).split('.')[0]);
+  console.log(`version: ${nodeMajorVersion}`);
+  if (nodeMajorVersion < 10) {
+    throw new Error(
+      `gts requires node.js 10.x or up. You are currently running
+      ${process.version}, which is not supported. Please upgrade to
+      a safe, secure version of nodejs!`
+    );
+  }
+
   const options = {
     dryRun: cli.flags.dryRun || false,
     // Paths are relative to the transpiled output files.

--- a/test/test-clean.ts
+++ b/test/test-clean.ts
@@ -35,7 +35,6 @@ describe('clean', () => {
   };
 
   it('should gracefully error if tsconfig is missing', () => {
-    // eslint-disable-next-line node/no-unsupported-features/node-builtins
     return assert.rejects(() =>
       withFixtures({}, async () => {
         await clean(OPTIONS);
@@ -61,7 +60,6 @@ describe('clean', () => {
   });
 
   it('should ensure that outDir is local to targetRoot', () => {
-    // eslint-disable-next-line node/no-unsupported-features/node-builtins
     return assert.rejects(() =>
       withFixtures(
         {


### PR DESCRIPTION
fixes #484