### PR TITLE
fix: prohibit calls to `it.only` and `describe.only`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,7 +17,18 @@
     "eol-last": "error",
     "prefer-arrow-callback": "error",
     "no-trailing-spaces": "error",
-    "quotes": ["warn", "single", { "avoidEscape": true }]
+    "quotes": ["warn", "single", { "avoidEscape": true }],
+    "no-restricted-properties": [
+      "error",
+      {
+        "object": "describe",
+        "property": "only"
+      },
+      {
+        "object": "it",
+        "property": "only"
+      }
+    ]
   },
   "overrides": [
     {


### PR DESCRIPTION
Prevent calls to ".only" in mocha tests. Porting upstream from nodeJS-firestore (original [PR](https://github.com/googleapis/nodejs-firestore/pull/1068)).