### PR TITLE
feat: generate .editorconfig

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -243,6 +243,19 @@ async function generatePrettierConfig(options: Options): Promise<void> {
   return generateConfigFile(options, './.prettierrc.js', style);
 }
 
+async function generateEditorConfig(options: Options): Promise<void> {
+  const config = `root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true
+`;
+  return generateConfigFile(options, './.editorconfig', config);
+}
+
 export async function installDefaultTemplate(
   options: Options
 ): Promise<boolean> {
@@ -309,6 +322,7 @@ export async function init(options: Options): Promise<boolean> {
   await generateTsConfig(options);
   await generateESLintConfig(options);
   await generatePrettierConfig(options);
+  await generateEditorConfig(options);
   await installDefaultTemplate(options);
 
   // Run `npm install` after initial setup so `npm run check` works right away.

--- a/test/kitchen.ts
+++ b/test/kitchen.ts
@@ -61,6 +61,7 @@ describe('🚰 kitchen sink', () => {
     fs.accessSync(path.join(kitchenPath, 'tsconfig.json'));
     fs.accessSync(path.join(kitchenPath, '.eslintrc.json'));
     fs.accessSync(path.join(kitchenPath, '.prettierrc.js'));
+    fs.accessSync(path.join(kitchenPath, '.editorconfig'));
 
     // Compilation shouldn't have happened. Hence no `build` directory.
     const dirContents = fs.readdirSync(kitchenPath);


### PR DESCRIPTION
resolve https://github.com/google/gts/issues/445

I agree that having `.editorconfig` would be nice. Not sure how the config should look like for this project though.