### PR TITLE
fix: better error message for broken tsconfig.json

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -76,10 +76,6 @@ async function getBase(
   readFiles.add(filePath);
   try {
     const json = await customReadFilep(filePath, 'utf8');
-  } catch (err) {
-    throw new Error(`${filePath} not found`);
-  }
-  try {
     let contents = JSON.parse(json);
 
     if (contents.extends) {
@@ -95,7 +91,7 @@ async function getBase(
 
     return contents;
   } catch (err) {
-    throw new Error(`${filePath} cannot be parsed`);
+    throw new Error(`Error: ${filePath}: ${err}`);
   }
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -76,6 +76,10 @@ async function getBase(
   readFiles.add(filePath);
   try {
     const json = await customReadFilep(filePath, 'utf8');
+  } catch (err) {
+    throw new Error(`${filePath} not found`);
+  }
+  try {
     let contents = JSON.parse(json);
 
     if (contents.extends) {
@@ -91,7 +95,7 @@ async function getBase(
 
     return contents;
   } catch (err) {
-    throw new Error(`${filePath} Not Found`);
+    throw new Error(`${filePath} cannot be parsed`);
   }
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -91,7 +91,8 @@ async function getBase(
 
     return contents;
   } catch (err) {
-    throw new Error(`Error: ${filePath}: ${err}`);
+    err.message = `Error: ${filePath}\n${err.message}`;
+    throw err;
   }
 }
 


### PR DESCRIPTION
If `tsconfig.json` cannot be parsed (invalid JSON) we should not say that it's not found.