### PR TITLE
feat: generate .eslintignore when running init

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -245,7 +245,8 @@ async function generateTsConfig(options: Options): Promise<void> {
 async function generatePrettierConfig(options: Options): Promise<void> {
   const style = `module.exports = {
   ...require('gts/.prettierrc.json')
-}`;
+}
+`;
   return generateConfigFile(options, './.prettierrc.js', style);
 }
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -181,6 +181,8 @@ export const ESLINT_CONFIG = {
   extends: './node_modules/gts/',
 };
 
+export const ESLINT_IGNORE = 'build/\n';
+
 async function generateConfigFile(
   options: Options,
   filename: string,
@@ -225,6 +227,10 @@ async function generateESLintConfig(options: Options): Promise<void> {
     './.eslintrc.json',
     formatJson(ESLINT_CONFIG)
   );
+}
+
+async function generateESLintIgnore(options: Options): Promise<void> {
+  return generateConfigFile(options, './.eslintignore', ESLINT_IGNORE);
 }
 
 async function generateTsConfig(options: Options): Promise<void> {
@@ -308,6 +314,7 @@ export async function init(options: Options): Promise<boolean> {
   }
   await generateTsConfig(options);
   await generateESLintConfig(options);
+  await generateESLintIgnore(options);
   await generatePrettierConfig(options);
   await installDefaultTemplate(options);
 

--- a/test/kitchen.ts
+++ b/test/kitchen.ts
@@ -60,6 +60,7 @@ describe('🚰 kitchen sink', () => {
     // Ensure config files got generated.
     fs.accessSync(path.join(kitchenPath, 'tsconfig.json'));
     fs.accessSync(path.join(kitchenPath, '.eslintrc.json'));
+    fs.accessSync(path.join(kitchenPath, '.eslintignore'));
     fs.accessSync(path.join(kitchenPath, '.prettierrc.js'));
 
     // Compilation shouldn't have happened. Hence no `build` directory.
@@ -120,6 +121,11 @@ describe('🚰 kitchen sink', () => {
     assert.ok(
       fs
         .readFileSync(path.join(kitchenPath, '.eslintrc.json'), 'utf8')
+        .endsWith('\n')
+    );
+    assert.ok(
+      fs
+        .readFileSync(path.join(kitchenPath, '.eslintignore'), 'utf8')
         .endsWith('\n')
     );
   });

--- a/test/kitchen.ts
+++ b/test/kitchen.ts
@@ -105,7 +105,7 @@ describe('🚰 kitchen sink', () => {
     }
   });
 
-  it('should terminate generated json files with newline', () => {
+  it('should terminate generated files with newline', () => {
     const GTS = path.resolve(stagingPath, gtsPath);
     spawn.sync(GTS, ['init', '-y'], execOpts);
     assert.ok(
@@ -126,6 +126,11 @@ describe('🚰 kitchen sink', () => {
     assert.ok(
       fs
         .readFileSync(path.join(kitchenPath, '.eslintignore'), 'utf8')
+        .endsWith('\n')
+    );
+    assert.ok(
+      fs
+        .readFileSync(path.join(kitchenPath, '.prettierrc.js'), 'utf8')
         .endsWith('\n')
     );
   });


### PR DESCRIPTION
- generate `.eslintignore` and include `build/`

- add empty line at enf of generated `.prettierrc.js`

solves https://github.com/google/gts/issues/483

solves https://github.com/google/gts/issues/520

