### PR TITLE
feat: ignore 'no-unused-vars' for _ var prefix

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -49,6 +49,7 @@
         "node/no-missing-import": "off",
         "node/no-empty-function": "off",
         "node/no-unsupported-features/es-syntax": "off",
+        "@typescript-eslint/no-unused-vars": ["warn", {"argsIgnorePattern": "^_"}],
         "node/no-missing-require": "off",
         "node/shebang": "off",
         "no-dupe-class-members": "off",


### PR DESCRIPTION
It's a common convention to use a `_` to specify that you do not intend to use a variable, an example would be the following code:

```js
(_err, req) => {
   console.info(req.headers)
}
```

This enables this functionality.

Refs: https://github.com/GoogleCloudPlatform/wombat-dressing-room/pull/76