### PR TITLE
fix: Add build/.eslintrc.json to the files field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "CHANGELOG.md",
     "build/src",
     "build/template",
+    "build/.eslintrc.json",
     ".prettierrc.json",
     "tsconfig-google.json",
     "tsconfig.json",


### PR DESCRIPTION
There is `.eslintrc.json` in `build/` directory that is generated by tsc. This file is loaded from `build/src/index.js` but not listed in the files field.

This is already included in published tarballs. 
```
$ curl -s https://registry.npmjs.org/gts/-/gts-2.0.2.tgz | tar tv | grep .eslintrc.json
   -rw-rw-r--  0 0      0        1407 10 26  1985 package/.eslintrc.json
   -rw-rw-r--  0 0      0        1663 10 26  1985 package/build/.eslintrc.json
```

This pr not only makes this package correct.
To add this file makes us able to use the head version from the GitHub repository, using `yarn add -D gts@git+https://github.com/google/gts.git#master`.

In installing from [git dependency](https://docs.npmjs.com/files/package.json#git-urls-as-dependencies), the `prepare` script runs and compiles typescript files. But now it doesn't work, yarn copies files listed in the `files` to under node_modules from cache directory where this compiled.
(But failed on npm. I guess npm is failing to execute chmod to set permissions for bin files not compiled yet.)
