### PR TITLE
fix(rule): turn off @typescript-eslint/no-var-requires

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -42,6 +42,7 @@
         "@typescript-eslint/no-use-before-define": "off",
         "@typescript-eslint/no-warning-comments": "off",
         "@typescript-eslint/no-empty-function": "off",
+        "@typescript-eslint/no-var-requires": "off",
         "@typescript-eslint/explicit-function-return-type": "off",
         "@typescript-eslint/explicit-module-boundary-types": "off",
         "@typescript-eslint/ban-types": "off",


### PR DESCRIPTION
It's a common pattern to `require('package.json')` to determine the version # of an application.

We do this in all of our auto generated code:

https://github.com/googleapis/nodejs-asset/pull/403/files

## Why this rule is a big problem for client libraries

If we switch these `require` statements to `import` statements, it breaks publication of our libraries, because TypeScript copies the `package.json` into the `build/` folder, which in turn stops npm from publishing assets in that folder.

## Another argument I'd make against this rule

`require` isn't just used for pulling in JavaScript files, it's convenient for loading JSON fixtures other than `package.json`, .e.g., `test/fixtures/foo.json` -- this is a useful pattern in tests which we'd now need to add ignore rules for.