### PR TITLE
Add no-confusing-void-expression rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,6 +38,7 @@
         "plugin:@typescript-eslint/recommended"
       ],
       "rules": {
+        "@typescript-eslint/no-confusing-void-expression": "error",
         "@typescript-eslint/no-non-null-assertion": "off",
         "@typescript-eslint/no-use-before-define": "off",
         "@typescript-eslint/no-warning-comments": "off",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^4.2.0",
+    "@typescript-eslint/eslint-plugin": "^4.7.0",
     "@typescript-eslint/parser": "^4.2.0",
     "chalk": "^4.1.0",
     "eslint": "^7.10.0",


### PR DESCRIPTION
I would like to add no-confusing-void-expression
introduce in 4.7.0 https://github.com/typescript-eslint/typescript-eslint/releases/tag/v4.7.0
as substitute of no-void-expression
https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/ROADMAP.md 