### PR TITLE
Re-jank template/index.ts

### DIFF
--- a/template/index.ts
+++ b/template/index.ts
@@ -1,24 +1,20 @@
-console.log('Try npm run lint/fix!');
+console.log("Try npm run lint/fix!");
 
-const longString =
-  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer ut aliquet diam.';
+const longString = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer ut aliquet diam.';
 
-const trailing = 'Semicolon';
+const trailing = 'Semicolon'
 
-const why = 'am I tabbed?';
+			const why = 'am I tabbed?';
 
-export function doSomeStuff(
-  withThis: string,
-  andThat: string,
-  andThose: string[]
-) {
-  //function on one line
-  if (!andThose.length) {
-    return false;
-  }
-  console.log(withThis);
-  console.log(andThat);
-  console.dir(andThose);
-  return;
+const iWish = "I didn't have a trailing space..."; 
+
+export function doSomeStuff(withThis: string, andThat: string, andThose: string[]) {
+    //function on one line
+    if(!andThose.length) {return false;}
+    console.log(withThis);
+    console.log(andThat);
+    console.dir(andThose);
+    console.log(longString, trailing, why, iWish);
+    return;
 }
 // TODO: more examples


### PR DESCRIPTION
Looks like `template/index.ts` was accidentally checked in "fixed" in https://github.com/google/gts/commit/b3096fb , it's supposed to be in need of linting.

This commit restores the (intentional) mistakes so new users can try running `npm run lint` and `npm run fix` and see what happens.

I also re-applied changes introduced in https://github.com/google/gts/commit/f9b20a6 and https://github.com/google/gts/commit/c527b66.

Added a new line which demonstrates removal of trailing space(s).

Oh, and I added a new `console.log` to get rid of "assigned a value but never used  @typescript-eslint/no-unused-vars" warnings, so users can have the satisfaction of a clean slate after running `npm run fix`.