### PR TITLE
build: throw on dependencies with incompatible engine

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
+      - run: npm i --production --engine-strict
       - run: node --version
       - run: npm ci
       - run: npm test


### PR DESCRIPTION
Add safety check to ensure dependencies have compatible engines field.