### PR TITLE
Revert "feat: no-floating-promises (#756)"

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,7 +38,6 @@
         "plugin:@typescript-eslint/recommended"
       ],
       "rules": {
-        "@typescript-eslint/no-floating-promises": "warn",
         "@typescript-eslint/no-non-null-assertion": "off",
         "@typescript-eslint/no-use-before-define": "off",
         "@typescript-eslint/no-warning-comments": "off",
@@ -58,7 +57,6 @@
       },
       "parserOptions": {
         "ecmaVersion": 2018,
-        "project": "./tsconfig.json",
         "sourceType": "module"
       }
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -169,7 +169,6 @@ if (cli.input.length < 1) {
   usage();
 }
 
-// eslint-disable-next-line @typescript-eslint/no-floating-promises
 run(cli.input[0], cli.input.slice(1)).then(success => {
   if (!success) {
     // eslint-disable-next-line no-process-exit


### PR DESCRIPTION
This reverts commit c93e73316164137e29daa7bea8a48083f7d7c1da.

This `project` property is breaking `lint` in the following libraries:
- https://github.com/googleapis/nodejs-googleapis-common
- https://github.com/googleapis/google-auth-library-nodejs
- https://github.com/googleapis/gaxios
- https://github.com/googleapis/nodejs-pubsub

Error message:

```
Parsing error: ESLint was configured to run on `<tsconfigRootDir>....` using `parserOptions.project`: .../tsconfig.json
However, that TSConfig does not include this file.
```

We should include this in the next major instead as the requires a coordinated release.