### PR TITLE
fix: Allow `typescript` v5+ as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,6 @@
     "typescript": "^5.6.3"
   },
   "peerDependencies": {
-    "typescript": ">=5.6.3"
+    "typescript": ">=5"
   }
 }


### PR DESCRIPTION
This isn't breaking as it is improving backwards compatibilty.