### PR TITLE
fix: TS `lib` Support for Node 18+

### DIFF
--- a/tsconfig-google.json
+++ b/tsconfig-google.json
@@ -4,7 +4,7 @@
     "allowUnusedLabels": false,
     "composite": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["es2018"],
+    "lib": ["es2023"],
     "module": "commonjs",
     "noEmitOnError": true,
     "noFallthroughCasesInSwitch": true,
@@ -13,7 +13,7 @@
     "sourceMap": true,
     "stripInternal": true,
     "strict": true,
-    "target": "es2018"
+    "target": "es2022"
   },
   "exclude": ["node_modules"]
 }

--- a/tsconfig-google.json
+++ b/tsconfig-google.json
@@ -4,7 +4,7 @@
     "allowUnusedLabels": false,
     "composite": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["es2023"],
+    "lib": ["ES2023"],
     "module": "commonjs",
     "noEmitOnError": true,
     "noFallthroughCasesInSwitch": true,
@@ -13,7 +13,7 @@
     "sourceMap": true,
     "stripInternal": true,
     "strict": true,
-    "target": "es2022"
+    "target": "ES2022"
   },
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Should be at least 2022 for `target`, 2023 for `lib`.

Background: https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping